### PR TITLE
Feature/improve OpenAI compatible

### DIFF
--- a/apps/pwa/src/components-v2/model/model-page-mobile.tsx
+++ b/apps/pwa/src/components-v2/model/model-page-mobile.tsx
@@ -73,7 +73,7 @@ const showBaseUrl = new Map<ApiSource, boolean>([
   [ApiSource.OpenAICompatible, true],
 ]);
 
-const showModelUrl = new Map<ApiSource, boolean>([[ApiSource.Wllama, true]]);
+const showModelUrl = new Map<ApiSource, boolean>([[ApiSource.OpenAICompatible, true]]);
 
 const showApiKey = new Map<ApiSource, boolean>([
   [ApiSource.OpenAI, true],
@@ -190,18 +190,7 @@ const descriptionBySource = new Map<ApiSource, React.ReactNode>([
   [
     ApiSource.OpenAICompatible,
     <>
-      Please note that you can only connect to endpoints that provide both
-      inference and model list APIs.
-      <br />
-      <br />
-      <ul className="list-disc ml-4">
-        <li>
-          Inference API: <code>/v1/chat/completions</code>
-        </li>
-        <li>
-          Model list API: <code>/v1/models</code>
-        </li>
-      </ul>
+      Please note that you can only connect to endpoints that provide inference API (<code>/v1/chat/completions</code>).
     </>,
   ],
 ]);
@@ -231,6 +220,12 @@ const renderProviderListItem = ({
   // Get details by source
   const details: ProviderListItemDetail[] = [];
   if (apiConnection) {
+    if (showModelUrl.get(source)) {
+      details.push({
+        label: "Model ID",
+        value: apiConnection.modelUrls?.join(", ") ?? "",
+      });
+    }
     if (showBaseUrl.get(source)) {
       details.push({
         label: "Base URL",
@@ -247,13 +242,7 @@ const renderProviderListItem = ({
           ) ?? "",
       });
     }
-    if (showModelUrl.get(source)) {
-      details.push({
-        label: "Model URL",
-        value: apiConnection.modelUrls?.join(", ") ?? "",
-      });
-    }
-    if (showApiKey.get(source)) {
+    if (showApiKey.get(source) && source !== ApiSource.OpenAICompatible) {
       details.push({
         label: "API key",
         value: maskApiKey(apiConnection.apiKey),
@@ -503,6 +492,7 @@ export default function ModelPageMobile({ className }: ModelPageMobileProps) {
         case ApiSource.OpenAICompatible:
           setApiKey(connection.apiKey ?? "");
           setBaseUrl(connection.baseUrl ?? "");
+          setModelUrl(connection.modelUrls?.join(", ") ?? "");
           break;
       }
 
@@ -808,6 +798,22 @@ export default function ModelPageMobile({ className }: ModelPageMobileProps) {
                         onChange={(e) => setBaseUrl(e.target.value)}
                       />
                     )}
+                  {editingApiConnection.source === ApiSource.OpenAICompatible && (
+                    <div
+                      className={cn(
+                        "flex flex-row gap-[4px] items-start",
+                        "font-[400] text-[14px] leading-[17px] text-text-secondary",
+                        "[&>a]:text-secondary-normal [&>a]:underline",
+                      )}
+                    >
+                      <div className="pt-[1px]">
+                        <Info size={16} />
+                      </div>
+                      <div>
+                        If the Base URL with <code>/v1</code> doesn't work, try without <code>/v1</code>, or vice versa.
+                      </div>
+                    </div>
+                  )}
                   {editingApiConnection.source &&
                     showApiKey.get(editingApiConnection.source) && (
                       <FloatingLabelInput
@@ -819,7 +825,7 @@ export default function ModelPageMobile({ className }: ModelPageMobileProps) {
                   {editingApiConnection.source &&
                     showModelUrl.get(editingApiConnection.source) && (
                       <FloatingLabelInput
-                        label="Model URL"
+                        label="Model ID"
                         value={modelUrl}
                         onChange={(e) => setModelUrl(e.target.value)}
                       />

--- a/apps/pwa/src/components-v2/setting/model-page.tsx
+++ b/apps/pwa/src/components-v2/setting/model-page.tsx
@@ -67,7 +67,7 @@ const showBaseUrl = new Map<ApiSource, boolean>([
   [ApiSource.OpenAICompatible, true],
 ]);
 
-const showModelUrl = new Map<ApiSource, boolean>([[ApiSource.Wllama, true]]);
+const showModelUrl = new Map<ApiSource, boolean>([[ApiSource.OpenAICompatible, true]]);
 
 const showApiKey = new Map<ApiSource, boolean>([
   [ApiSource.OpenAI, true],
@@ -184,18 +184,7 @@ const descriptionBySource = new Map<ApiSource, React.ReactNode>([
   [
     ApiSource.OpenAICompatible,
     <>
-      Please note that you can only connect to endpoints that provide both
-      inference and model list APIs.
-      <br />
-      <br />
-      <ul className="list-disc ml-4">
-        <li>
-          Inference API: <code>/v1/chat/completions</code>
-        </li>
-        <li>
-          Model list API: <code>/v1/models</code>
-        </li>
-      </ul>
+      Please note that you can only connect to endpoints that provide inference API (<code>/v1/chat/completions</code>).
     </>,
   ],
 ]);
@@ -223,6 +212,12 @@ const renderProviderListItem = ({
   // Get details by source
   const details: ProviderListItemDetail[] = [];
   if (apiConnection) {
+    if (showModelUrl.get(source)) {
+      details.push({
+        label: "Model ID",
+        value: apiConnection.modelUrls?.join(", ") ?? "",
+      });
+    }
     if (showBaseUrl.get(source)) {
       details.push({
         label: "Base URL",
@@ -239,13 +234,7 @@ const renderProviderListItem = ({
           ) ?? "",
       });
     }
-    if (showModelUrl.get(source)) {
-      details.push({
-        label: "Model URL",
-        value: apiConnection.modelUrls?.join(", ") ?? "",
-      });
-    }
-    if (showApiKey.get(source)) {
+    if (showApiKey.get(source) && source !== ApiSource.OpenAICompatible) {
       details.push({
         label: "API key",
         value: maskApiKey(apiConnection.apiKey),
@@ -368,6 +357,7 @@ export default function ModelPage({ className }: { className?: string }) {
         case ApiSource.OpenAICompatible:
           setApiKey(connection.apiKey ?? "");
           setBaseUrl(connection.baseUrl ?? "");
+          setModelUrl(connection.modelUrls?.join(", ") ?? "");
           break;
       }
 
@@ -637,6 +627,22 @@ export default function ModelPage({ className }: { className?: string }) {
                 onChange={(e) => setBaseUrl(e.target.value)}
               />
             )}
+          {editingApiConnection?.source === ApiSource.OpenAICompatible && (
+            <div
+              className={cn(
+                "mt-[-16px] flex flex-row gap-[4px] items-start",
+                "font-[400] text-[16px] leading-[19px] text-text-secondary",
+                "[&>a]:text-secondary-normal",
+              )}
+            >
+              <div className="pt-[1px]">
+                <Info size={16} />
+              </div>
+              <div>
+                If the Base URL with <code>/v1</code> doesn't work, try without <code>/v1</code>, or vice versa.
+              </div>
+            </div>
+          )}
           {editingApiConnection?.source &&
             showApiKey.get(editingApiConnection?.source) && (
               <FloatingLabelInput
@@ -648,7 +654,7 @@ export default function ModelPage({ className }: { className?: string }) {
           {editingApiConnection?.source &&
             showModelUrl.get(editingApiConnection?.source) && (
               <FloatingLabelInput
-                label="Model URL"
+                label="Model ID"
                 value={modelUrl}
                 onChange={(e) => setModelUrl(e.target.value)}
               />

--- a/apps/pwa/src/modules/api/usecases/check-api-key.ts
+++ b/apps/pwa/src/modules/api/usecases/check-api-key.ts
@@ -39,7 +39,7 @@ export class CheckApiKey implements UseCase<ApiConnection, Result<boolean>> {
     );
     this.strategies.set(
       ApiSource.OpenAICompatible,
-      new ListOpenaiCompatibleModelStrategy(this.httpClient),
+      new ListOpenaiCompatibleModelStrategy(),
     );
     this.strategies.set(ApiSource.Wllama, new ListWllamaModelStrategy());
     this.strategies.set(

--- a/apps/pwa/src/modules/api/usecases/list-api-model/list-api-model.ts
+++ b/apps/pwa/src/modules/api/usecases/list-api-model/list-api-model.ts
@@ -56,7 +56,7 @@ export class ListApiModel
     );
     this.strategies.set(
       ApiSource.OpenAICompatible,
-      new ListOpenaiCompatibleModelStrategy(this.httpClient),
+      new ListOpenaiCompatibleModelStrategy(),
     );
     this.strategies.set(ApiSource.Wllama, new ListWllamaModelStrategy());
     this.strategies.set(

--- a/apps/pwa/src/modules/api/usecases/list-api-model/list-openai-compatible-model-strategy.ts
+++ b/apps/pwa/src/modules/api/usecases/list-api-model/list-openai-compatible-model-strategy.ts
@@ -1,38 +1,24 @@
 import { Result } from "@/shared/core/result";
-import { OpenAIComptableEndpoint } from "@/shared/endpoints";
-import { HttpClient } from "@/shared/infra";
 import { formatFail } from "@/shared/utils/error-utils";
 
 import { ApiConnection, ApiModel } from "@/modules/api/domain";
 import { ListApiModelStrategy } from "@/modules/api/usecases/list-api-model/list-api-model-strategy";
 
 export class ListOpenaiCompatibleModelStrategy implements ListApiModelStrategy {
-  constructor(private httpClient: HttpClient) {}
+  constructor() {}
 
   async listApiModel(
     apiConnection: ApiConnection,
   ): Promise<Result<ApiModel[]>> {
     try {
       if (!apiConnection.props.apiKey) {
-        throw new Error("API key is missing for OpenAI connection");
+        throw new Error("API key is missing for OpenAI compatible connection");
       }
 
-      const endpoint = new OpenAIComptableEndpoint(
-        this.httpClient,
-        apiConnection.props.apiKey,
-        apiConnection.props.baseUrl,
-      );
-
-      let modelList = await endpoint.getAvailableModelList();
-
-      if (apiConnection.modelUrls) {
-        modelList = [
-          ...modelList,
-          ...apiConnection.modelUrls.map((url) =>
-            ApiModel.create({ id: url, name: url }).getValue(),
-          ),
-        ];
-      }
+      const modelList =
+        apiConnection.modelUrls?.map((url) =>
+          ApiModel.create({ id: url, name: url }).getValue(),
+        ) ?? [];
 
       return Result.ok(modelList);
     } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the interface for OpenAI-compatible providers to use "Model ID" instead of "Model URL".
  * Added an informational message for OpenAI-compatible connections, advising users to try the Base URL with or without the /v1 suffix.

* **Improvements**
  * Simplified and clarified the description text for OpenAI-compatible providers.
  * Reordered provider details to display "Model ID" before "Base URL".
  * The API key is now hidden in the provider list for OpenAI-compatible connections.

* **Bug Fixes**
  * Improved handling and validation of the "Model ID" field when editing OpenAI-compatible connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->