### PR TITLE
fix: ai sdk default temperature is zero

### DIFF
--- a/apps/pwa/src/app/services/session-play-service.ts
+++ b/apps/pwa/src/app/services/session-play-service.ts
@@ -343,6 +343,11 @@ const makeSettings = ({ parameters }: { parameters: Map<string, any> }) => {
 
   if (parameters.has("temperature")) {
     settings["temperature"] = Number(parameters.get("temperature"));
+  } else {
+    // Prevent AI SDK set temperature to 0
+    // TODO: delete this code after upgrade to AI SDK v5
+    // https://ai-sdk.dev/docs/ai-sdk-core/settings#temperature
+    settings["temperature"] = 1;
   }
 
   if (parameters.has("top_p")) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the "temperature" setting defaults to 1 when not specified, preventing unintended behavior during AI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->