### PR TITLE
Fix card search width

### DIFF
--- a/apps/pwa/src/components-v2/left-navigation/card-list.tsx
+++ b/apps/pwa/src/components-v2/left-navigation/card-list.tsx
@@ -548,7 +548,7 @@ const CardSection = ({
         onboardingHelpGlow={onboardingHelpGlow}
       />
       <div className={cn(!expanded && "hidden")}>
-        <div className="pl-8 pr-4 py-2 flex flex-row gap-2 items-center w-[320px]">
+        <div className="pl-8 pr-4 py-2 flex flex-row gap-2 items-center w-[315px]">
           <SearchInput
             className="grow"
             value={keyword}


### PR DESCRIPTION
Fix width issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Adjusted the search field container width in the left navigation to improve alignment and reduce minor overflow in tight layouts.
  - This is a purely visual polish; no behavior or data flow changes. Users may notice slightly more consistent spacing around the search input.
  - Enhances visual balance and maintains readability across varying sidebar widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->