### PR TITLE
fix: background initialization

### DIFF
--- a/apps/pwa/src/components-v2/session/edit-session/edit-background.tsx
+++ b/apps/pwa/src/components-v2/session/edit-session/edit-background.tsx
@@ -51,7 +51,6 @@ const SelectedBackground = ({
               src={asset}
               alt={background?.name ?? "Background"}
               className="pointer-events-none w-full h-full object-cover"
-
             />
           </div>
         )
@@ -81,9 +80,9 @@ const EditBackground = ({
 
   // Handle background click with auto-save
   const handleBackgroundClick = useCallback(
-    async (newBackgroundId: UniqueEntityID) => {
+    async (newBackgroundId?: UniqueEntityID) => {
       // Set form value
-      if (backgroundId === newBackgroundId.toString()) {
+      if (!newBackgroundId || backgroundId === newBackgroundId.toString()) {
         setValue("backgroundId", null);
         await onSave({
           backgroundId: undefined,
@@ -225,10 +224,9 @@ const EditBackground = ({
           <div className="grid grid-cols-2 gap-4">
             <BackgroundListItem
               isActive={!backgroundId}
-              onClick={() => {
-                setValue("backgroundId", null);
-              }}
+              onClick={() => handleBackgroundClick()}
             />
+
             {defaultBackgrounds.map((defaultBackground) => (
               <BackgroundListItem
                 key={defaultBackground.id.toString()}


### PR DESCRIPTION
Background initialization issue fixed:

- Missing save when selecting default background
- Made newBackgroundId parameter optional in handleBackgroundClick function
- Unified background selection method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now remove a session background by selecting the “No background” option, clearing any previously chosen background.
- Bug Fixes
  - Clicking the default/backgroundless tile reliably clears the background selection.
  - Background selection and deselection behave consistently, preventing accidental re-selection when clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->