### PR TITLE
fix: delete iframe-autoplay

### DIFF
--- a/apps/pwa/src/components-v2/setting/onboarding-step-one-page.tsx
+++ b/apps/pwa/src/components-v2/setting/onboarding-step-one-page.tsx
@@ -33,9 +33,9 @@ const OnboardingStepOnePage = () => {
           <iframe
             width="100%"
             height="100%"
-            src="https://www.youtube.com/embed/vO6JFL6R_mc?autoplay=1&mute=1&cc_load_policy=1&start=0"
+            src="https://www.youtube.com/embed/vO6JFL6R_mc?mute=1&cc_load_policy=1&start=0"
             title="astrsk Tutorial"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
           />
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled autoplay for the onboarding video to prevent unexpected playback and improve user experience. Video remains muted with captions enabled and starts from the beginning. Navigation and layout are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->