### PR TITLE
Enhance OAuth handling in app initialization

### DIFF
--- a/apps/pwa/src/routes/_layout/auth/callback.tsx
+++ b/apps/pwa/src/routes/_layout/auth/callback.tsx
@@ -73,7 +73,14 @@ function AuthCallback() {
 
           // Set flag to indicate we're coming from OAuth callback
           // This allows main.tsx to defer PGlite initialization
-          sessionStorage.setItem("astrsk-oauth-redirect", "true");
+          // Wrapped in try-catch for private browsing mode compatibility
+          try {
+            sessionStorage.setItem("astrsk-oauth-redirect", "true");
+          } catch (e) {
+            // sessionStorage may be unavailable in private browsing mode
+            // Continue with redirect anyway - initialization will happen normally
+            logger.warn("Failed to set OAuth redirect flag:", e);
+          }
 
           // Hard redirect to settings page
           window.location.href = "/settings";

--- a/apps/pwa/src/routes/_layout/auth/callback.tsx
+++ b/apps/pwa/src/routes/_layout/auth/callback.tsx
@@ -71,8 +71,11 @@ function AuthCallback() {
           logger.debug("OAuth login successful, redirecting to settings...");
           setStatus("Success! Redirecting...");
 
-          // Hard redirect to settings page - this ensures fresh page load
-          // and proper PGlite initialization on iOS Chrome
+          // Set flag to indicate we're coming from OAuth callback
+          // This allows main.tsx to defer PGlite initialization
+          sessionStorage.setItem("astrsk-oauth-redirect", "true");
+
+          // Hard redirect to settings page
           window.location.href = "/settings";
         } else {
           logger.warn("No session after OAuth callback");


### PR DESCRIPTION
- Updated the initialization logic to defer PGlite initialization when redirected from the OAuth callback, preventing hangs on iOS Chrome/Safari.
- Introduced a session storage flag to indicate OAuth redirects, allowing for smoother transitions post-authentication.
- Improved comments for clarity on the initialization flow and its implications for user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved OAuth redirects hanging on iOS Chrome and Safari; login now completes reliably.
  * Added a short-page-reload flow with a visible loading state to smooth post-auth redirects.
  * Improved handling when browser storage is restricted (private browsing), falling back gracefully and continuing initialization.
* **Improvements**
  * More robust OAuth callback flow to ensure the app becomes ready after redirect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->