### PR TITLE
Temporarily disable BroadcastChannel for OAuth debugging on iOS

### DIFF
--- a/apps/pwa/src/shared/api/query-client.ts
+++ b/apps/pwa/src/shared/api/query-client.ts
@@ -129,7 +129,8 @@ persistQueryClient({
 
 // Initialize broadcast for multi-tab sync (skip for web version)
 // VITE_SKIP_WAITING=true disables broadcast to prevent multi-tab sync issues in web mode
-if (import.meta.env.VITE_SKIP_WAITING !== "true") {
+// TEMPORARILY DISABLED for OAuth hang debugging - testing if BroadcastChannel causes iOS issues
+if (false && import.meta.env.VITE_SKIP_WAITING !== "true") {
   broadcastQueryClient({
     queryClient,
     broadcastChannel: "astrsk-query-broadcast",


### PR DESCRIPTION
- Commented out the BroadcastChannel initialization to investigate potential issues causing hangs during OAuth processes on iOS.
- This change is intended for testing and will help determine if the BroadcastChannel is contributing to the observed problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Multi-tab broadcast synchronization has been temporarily disabled pending further updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->